### PR TITLE
Fix missing import in SQLite mutation hook

### DIFF
--- a/src/hooks/use-sqlite-mutation.ts
+++ b/src/hooks/use-sqlite-mutation.ts
@@ -1,4 +1,5 @@
 import { MutationOptions, useMutation } from "react-query";
+import { SQLResultSet } from "expo-sqlite";
 import { useDB } from "../providers/SQLiteProvider";
 
 type Variables<TVariables = void> = (


### PR DESCRIPTION
## Summary
- fix undefined `SQLResultSet` type by importing it from expo-sqlite

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7e7e7b64832e82ee61ded3105f95