### PR TITLE
Fix backup upload handler mapping

### DIFF
--- a/src/screens/Settings/hooks/use-upload-backup-handler.ts
+++ b/src/screens/Settings/hooks/use-upload-backup-handler.ts
@@ -74,13 +74,13 @@ function useUploadBackupHandler(options?: UseMutationOptions<void, string>) {
       {}
     );
 
-    await Promise.all([
+    await Promise.all(
       backup.map((post) => {
         if (!hash[post.value]) {
           return createPost({ text: post.value, timestamp: post.timestamp });
         }
-      }),
-    ]);
+      })
+    );
   }, options);
 }
 


### PR DESCRIPTION
## Summary
- fix usage of Promise.all when uploading backups

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ff29a98832e9a39d243ce8c9fc9