### PR TITLE
Add image attachment to posts

### DIFF
--- a/src/components/PostsList.tsx
+++ b/src/components/PostsList.tsx
@@ -20,6 +20,8 @@ import { Post } from "../shared/SQLiteEntities";
 import { Frame } from "./Frame";
 import { Icon } from "./Icon/Icon";
 import { PostTextContent } from "./PostTextContent";
+import { Picture } from "./Picture";
+import { base64ToImageUrl } from "../shared/image-utils";
 import { UserAvatar } from "./UserAvatar";
 
 const PostsList = React.forwardRef<
@@ -82,7 +84,7 @@ const PostsList = React.forwardRef<
 });
 
 const POST_ITEM_HEIGHT = 130;
-const PostLine = React.memo(function PostLine({ id, value }: Post) {
+const PostLine = React.memo(function PostLine({ id, value, image }: Post) {
   const { paddingHorizontal } = usePaddingHorizontal();
   const { navigate } = useNavigation<NavigationProp<NavigationParamsConfig>>();
   const theme = useTheme();
@@ -134,6 +136,11 @@ const PostLine = React.memo(function PostLine({ id, value }: Post) {
             <PostTextContent value={value} numberOfLines={6} />
           </Frame>
         </Frame>
+        {image && (
+          <Frame marginTop="small">
+            <Picture source={{ uri: base64ToImageUrl(image) }} />
+          </Frame>
+        )}
       </Frame>
     </Pressable>
   );

--- a/src/hooks/use-create-post.ts
+++ b/src/hooks/use-create-post.ts
@@ -6,6 +6,7 @@ import { useSQLiteMutation } from "./use-sqlite-mutation";
 
 interface Variables {
   text: string;
+  image?: string | null;
   timestamp?: string;
 }
 
@@ -17,13 +18,13 @@ function useCreatePost(options?: UseMutationOptions<Data, string, Variables>) {
   const { mutate: invalidatePosts } = useInvalidatePosts();
   const { mutateAsync: insertHashtag } = useInsertHashtags();
   const { mutateAsync: insertPost } = useSQLiteMutation<Variables>({
-    mutation: "insert into posts (value) values (?)",
-    variables: ({ text }) => [text],
+    mutation: "insert into posts (value, image) values (?, ?)",
+    variables: ({ text, image }) => [text, image || null],
   });
 
   const { mutateAsync: insertPostFromBackup } = useSQLiteMutation<Variables>({
-    mutation: "insert into posts (value, timestamp) values (?, ?)",
-    variables: ({ text, timestamp }) => [text, timestamp],
+    mutation: "insert into posts (value, image, timestamp) values (?, ?, ?)",
+    variables: ({ text, image, timestamp }) => [text, image || null, timestamp],
   });
 
   return useMutation<Data, string, Variables>(

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -6,6 +6,7 @@ import { Frame } from "../components/Frame";
 import { NavigationHeader } from "../components/NavigationHeader";
 import { PostInputAccessory } from "../components/PostInputAccessory";
 import { PostTextContent } from "../components/PostTextContent";
+import { Icon } from "../components/Icon/Icon";
 import { useTextCaretWord } from "../hooks/use-text-caret-word";
 import { usePaddingHorizontal } from "../providers/Theming/hooks/use-padding-horizontal";
 import { useTheme } from "../providers/Theming/hooks/use-theme";
@@ -14,14 +15,16 @@ interface Props {
   text: string;
   changeText: (text: string) => void;
   onCreatePostPress?: () => void;
+  onAddImagePress?: () => void;
   children?: React.ReactNode;
   navigationHeaderChildren?: React.ReactNode;
   beforeTextContent?: React.ReactNode;
+  bottomChildren?: React.ReactNode;
 }
 
 const PostLayout = React.forwardRef<TextInput & NativeMethods, Props>(
   function PostLayout(
-    { changeText, text, children, onCreatePostPress, beforeTextContent },
+    { changeText, text, children, onCreatePostPress, onAddImagePress, beforeTextContent, bottomChildren },
     ref: React.Ref<TextInput & NativeMethods>
   ) {
     const theme = useTheme();
@@ -70,6 +73,16 @@ const PostLayout = React.forwardRef<TextInput & NativeMethods, Props>(
           caretWord={caretWord}
           onHashtagSelected={(text) => changeText(text)}
         >
+          {onAddImagePress && (
+            <Pressable
+              onPress={onAddImagePress}
+              style={{
+                marginRight: theme.units.small,
+              }}
+            >
+              <Icon type="Plus" size="medium" color="primary" />
+            </Pressable>
+          )}
           {onCreatePostPress && (
             <Pressable
               onPress={onCreatePostPress}
@@ -87,6 +100,7 @@ const PostLayout = React.forwardRef<TextInput & NativeMethods, Props>(
             </Pressable>
           )}
         </PostInputAccessory>
+        {bottomChildren}
       </>
     );
   }

--- a/src/providers/SQLiteProvider.tsx
+++ b/src/providers/SQLiteProvider.tsx
@@ -20,7 +20,7 @@ const SQLiteProvider: React.FunctionComponent = function SQLiteProvider({
   useEffect(() => {
     db.transaction((tx) => {
       tx.executeSql(
-        "create table if not exists posts (id integer primary key not null, value text,  timestamp datetime default current_timestamp);"
+        "create table if not exists posts (id integer primary key not null, value text, image text, timestamp datetime default current_timestamp);"
       );
       tx.executeSql(
         "create table if not exists hashtags (id integer primary key not null, value text,  timestamp datetime default current_timestamp, post_id integer not null);"

--- a/src/screens/Create.tsx
+++ b/src/screens/Create.tsx
@@ -11,15 +11,19 @@ import React, { useEffect, useRef, useState } from "react";
 import { Alert, NativeMethods } from "react-native";
 import { TextInput } from "react-native-gesture-handler";
 import { Frame } from "../components/Frame";
+import { Picture } from "../components/Picture";
 import { UserAvatar } from "../components/UserAvatar";
 import { useCreatePost } from "../hooks/use-create-post";
 import { PostLayout } from "../layouts/PostLayout";
 import { NavigationParamsConfig } from "../shared/NavigationParamsConfig";
+import { base64ToImageUrl } from "../shared/image-utils";
+import { pickImage } from "../shared/pick-image";
 
 function Create() {
   const params = useRoute<RouteProp<NavigationParamsConfig, "Create">>().params;
   const ref = useRef<(TextInput & NativeMethods) | null>(null);
   const [text, changeText] = useState(params?.initialTextContent || "");
+  const [image, setImage] = useState<string | null>(null);
   const navigation = useNavigation<NavigationProp<NavigationParamsConfig>>();
   const { mutate: createPost, status } = useCreatePost({
     onSuccess: () => {
@@ -72,9 +76,26 @@ function Create() {
       ref={ref}
       text={text}
       changeText={changeText}
+      onAddImagePress={
+        image
+          ? undefined
+          : async () => {
+              const result = await pickImage();
+              if (result?.base64) {
+                setImage(result.base64);
+              }
+            }
+      }
+      bottomChildren={
+        image ? (
+          <Frame marginTop="small" paddingHorizontal="medium">
+            <Picture source={{ uri: base64ToImageUrl(image) }} />
+          </Frame>
+        ) : null
+      }
       onCreatePostPress={() => {
         if (text) {
-          createPost({ text });
+          createPost({ text, image });
         }
       }}
     >

--- a/src/screens/PostDetails.tsx
+++ b/src/screens/PostDetails.tsx
@@ -12,6 +12,7 @@ import { Pressable } from "react-native";
 import { Font } from "../components/Font";
 import { Frame } from "../components/Frame";
 import { Icon } from "../components/Icon/Icon";
+import { Picture } from "../components/Picture";
 import { PostLayout } from "../layouts/PostLayout";
 import { useDebounceValue } from "../hooks/use-debounce-value";
 import { useEditPost } from "../hooks/use-edit-post";
@@ -23,6 +24,7 @@ import { QueryKeys } from "../shared/QueryKeys";
 import { Post } from "../shared/SQLiteEntities";
 import { usePaddingHorizontal } from "../providers/Theming/hooks/use-padding-horizontal";
 import { useTheme } from "../providers/Theming/hooks/use-theme";
+import { base64ToImageUrl } from "../shared/image-utils";
 
 const PostDetails = React.memo(function PostDetails() {
   const {
@@ -128,6 +130,13 @@ const PostDetails = React.memo(function PostDetails() {
             <Icon type="More" size="medium" color="primary" />
           </Pressable>
         </Frame>
+      }
+      bottomChildren={
+        post?.image ? (
+          <Frame marginTop="small" paddingHorizontal={paddingHorizontal}>
+            <Picture source={{ uri: base64ToImageUrl(post.image) }} />
+          </Frame>
+        ) : null
       }
     />
   );

--- a/src/screens/Settings/hooks/use-upload-backup-handler.ts
+++ b/src/screens/Settings/hooks/use-upload-backup-handler.ts
@@ -37,7 +37,7 @@ function usePickDocumentMutation() {
       });
     }
 
-    return JSON.parse(result) as Pick<Post, "timestamp" | "value">[];
+    return JSON.parse(result) as Pick<Post, "timestamp" | "value" | "image">[];
   });
 }
 
@@ -77,7 +77,11 @@ function useUploadBackupHandler(options?: UseMutationOptions<void, string>) {
     await Promise.all(
       backup.map((post) => {
         if (!hash[post.value]) {
-          return createPost({ text: post.value, timestamp: post.timestamp });
+          return createPost({
+            text: post.value,
+            image: (post as any).image,
+            timestamp: post.timestamp,
+          });
         }
       })
     );

--- a/src/shared/SQLiteEntities.ts
+++ b/src/shared/SQLiteEntities.ts
@@ -6,5 +6,6 @@ export interface Tag {
 export interface Post {
   id: string;
   value: string;
+  image: string | null;
   timestamp: string;
 }

--- a/src/shared/pick-image.ts
+++ b/src/shared/pick-image.ts
@@ -1,0 +1,22 @@
+import * as ImagePicker from "expo-image-picker";
+
+async function pickImage(): Promise<{ base64?: string } | null> {
+  try {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 0.7,
+      base64: true,
+    });
+
+    if (result.cancelled) {
+      return null;
+    }
+
+    return { base64: result.base64 };
+  } catch (e) {
+    throw new Error(e as any);
+  }
+}
+
+export { pickImage };


### PR DESCRIPTION
## Summary
- allow picking an image for new posts
- display optional post image in timeline and post page
- store optional image in SQLite table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f815e50b4832e9ec1cbe748f443cf